### PR TITLE
chore(CI): introduce PR title conventional commits validator

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -10,6 +10,7 @@ ignorePatterns:
   - '!.*'
   - '**/node_modules/.*'
   - '**/dist/.*'
+  - '.github/commitlint.config.js'
 
 parser: '@typescript-eslint/parser'
 

--- a/.github/commitlint.config.js
+++ b/.github/commitlint.config.js
@@ -1,0 +1,21 @@
+// Source: @commitlint/config-conventional
+module.exports = {
+  rules: {
+    'body-leading-blank': [1, 'always'],
+    'body-max-line-length': [2, 'always', 100],
+    'footer-leading-blank': [1, 'always'],
+    'footer-max-line-length': [2, 'always', 100],
+    'header-max-length': [2, 'always', 100],
+    'scope-empty': [2, 'never'],
+    'subject-case': [2, 'never', ['start-case', 'pascal-case', 'upper-case']],
+    'subject-empty': [2, 'never'],
+    'subject-full-stop': [2, 'never', '.'],
+    'type-case': [2, 'always', 'lower-case'],
+    'type-empty': [2, 'never'],
+    'type-enum': [
+      2,
+      'always',
+      ['build', 'chore', 'ci', 'docs', 'feat', 'fix', 'perf', 'refactor', 'revert', 'style', 'test']
+    ]
+  }
+};

--- a/.github/workflows/conventional-commits.yaml
+++ b/.github/workflows/conventional-commits.yaml
@@ -1,0 +1,22 @@
+name: Conventional Commits
+
+on:
+  #  https://github.com/marketplace/actions/semantic-pull-request#event-triggers:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+
+permissions:
+  pull-requests: read
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/conventional-commits.yaml
+++ b/.github/workflows/conventional-commits.yaml
@@ -1,7 +1,7 @@
 name: Conventional Commits
 
 on:
-  #  https://github.com/marketplace/actions/semantic-pull-request#event-triggers:
+  # https://github.com/marketplace/actions/semantic-pull-request#event-triggers
   pull_request:
     types:
       - opened
@@ -15,7 +15,7 @@ permissions:
 jobs:
   main:
     name: Validate PR title
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: benhodgson87/conventional-pull-request-action@v0.1.3
         env:

--- a/.github/workflows/conventional-commits.yaml
+++ b/.github/workflows/conventional-commits.yaml
@@ -17,6 +17,10 @@ jobs:
     name: Validate PR title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - uses: benhodgson87/conventional-pull-request-action@v0.1.3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          commitlintRulesPath: ".github/commitlint.config.js"
+          commitTitleMatch: "false"
+          ignoreCommits: "true"


### PR DESCRIPTION
Validate PR title against conventional commit specification.

Docs: https://www.conventionalcommits.org/en/v1.0.0/

We want to use conventional commits to automate release and release versioning.