### PR TITLE
chore: use semantic PR commits in renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "local>Lendable/renovate-config"
+    "local>Lendable/renovate-config",
+    ":semanticCommits"
   ]
 }


### PR DESCRIPTION
Configure RenovateBot to use semantic commit messages.
