### PR TITLE
chore: trigger Release PR github actions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,8 +19,8 @@ jobs:
       - uses: tibdex/github-app-token@v2
         id: generate-token
         with:
-          app_id: ${{ secrets.APP_ID }}
-          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+          app_id: ${{ secrets.LENDABOT_APP_ID }}
+          private_key: ${{ secrets.LENDABOT_APP_PRIVATE_KEY }}
 
       - uses: google-github-actions/release-please-action@v4
         id: release

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,9 +16,16 @@ jobs:
     runs-on: ubuntu-22.04
     name: Release Automation
     steps:
+      - uses: tibdex/github-app-token@v2
+        id: generate-token
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - uses: google-github-actions/release-please-action@v4
         id: release
         with:
+          token: ${{ steps.generate-token.outputs.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
           include-component-in-tag: false
@@ -30,7 +37,7 @@ jobs:
         run: |
           git config user.name github-actions[bot]
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
-          git remote add gh-token "https://${{ secrets.GITHUB_TOKEN }}@github.com/Lendable/sloth.git"
+          git remote add gh-token "https://${{ steps.generate-token.outputs.token }}@github.com/Lendable/sloth.git"
           git tag -d v${{ steps.release.outputs.major }} || true
           git tag -d v${{ steps.release.outputs.major }}.${{ steps.release.outputs.minor }} || true
           git push origin :v${{ steps.release.outputs.major }} || true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,6 +21,7 @@ jobs:
         with:
           app_id: ${{ secrets.LENDABOT_APP_ID }}
           private_key: ${{ secrets.LENDABOT_APP_PRIVATE_KEY }}
+          repositories: [Lendable/sloth]
 
       - uses: google-github-actions/release-please-action@v4
         id: release


### PR DESCRIPTION
We want Release PR to trigger the GitHub actions. When GH Action creates a PR by default, it does not initiate actions. This prevents you from accidentally creating recursive workflow runs.

Documentation: https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow

One of the solutions - use the token from the GitHub app.

**Create new Application**
Note: you can use an existing app if you already have for this purpose.
https://github.com/settings/apps/new

Where can this GitHub App be installed: only for this account.

**Set required permissions**
Contents: read and write
Metadata: read-only
Pull requests: read and write

**Generate private key**
It will trigger download automatically. Store it for later use in a secure location.
Note the Application id - we will need it later.

**Install application**
Install the application and assign there required repository (or repositories) for the application.

**Set application secrets**
In the repository secrets configure two new entries for actions:
`APP_ID` - application id
`APP_PRIVATE_KEY` - private application key

The `tibdex/github-app-token` action will generate a temporary token and revoke it after the action.