### PR TITLE
chore: use lower case repository name when obtaining token for release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,7 +22,7 @@ jobs:
           app_id: ${{ secrets.LENDABOT_APP_ID }}
           private_key: ${{ secrets.LENDABOT_APP_PRIVATE_KEY }}
           repositories: >-
-            ["Lendable/sloth"]
+            ["lendable/sloth"]
 
       - uses: google-github-actions/release-please-action@v4
         id: release


### PR DESCRIPTION
This is failing at present, trying with lower case despite that feeling weird as the org is `Lendable` rather than `lendable`. Have confirmed App has this repository in the allow list.