### PR TITLE
chore: remove repository restriction when creating release access token

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,8 +19,6 @@ jobs:
         with:
           app_id: ${{ secrets.LENDABOT_APP_ID }}
           private_key: ${{ secrets.LENDABOT_APP_PRIVATE_KEY }}
-          repositories: >-
-            ["lendable/sloth"]
 
       - uses: google-github-actions/release-please-action@v4
         id: release


### PR DESCRIPTION
The GitHub App is restricted to this repository already.