### PR TITLE
chore: default to internal actions token

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ on:
   pull_request:
   merge_group:
 
+permissions:
+  contents: read
+  checks: read
+
 jobs:
   sloth:
     runs-on: ubuntu-22.04

--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,7 @@ inputs:
   token:
     description: "GitHub token to use to interact with the GitHub API."
     default: "${{ github.token }}"
-    required: true
+    required: false
   ref:
     description: "Git reference to inspect check runs for. The default supports Pull Requests, Merge Queues as well as branch pushes."
     required: false

--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,7 @@ branding:
 inputs:
   token:
     description: "GitHub token to use to interact with the GitHub API."
+    default: "${{ github.token }}"
     required: true
   ref:
     description: "Git reference to inspect check runs for. The default supports Pull Requests, Merge Queues as well as branch pushes."


### PR DESCRIPTION
## Overview

Most common actions needing the standard GitHub actions token set the default behind the scenes. 