### PR TITLE
chore(DEVOPS-10483): standardise renovate config to devops preset

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "local>Lendable/renovate-config-public",
-    ":semanticCommits"
-  ]
+  "extends": ["local>Lendable/renovate-config//teams/devops/default"]
 }


### PR DESCRIPTION
## DEVOPS-10483

## Changes
- Standardise `renovate.json` to use the common devops team preset (`local>Lendable/renovate-config//teams/devops/default`)
- Remove ad-hoc overrides in favour of the shared preset

## Tests
- [ ] Verify Renovate bot picks up the new config correctly on next scheduled run

🤖 Generated with [Claude Code](https://claude.com/claude-code)